### PR TITLE
fix logic and add a singular comment for both talonFX variants

### DIFF
--- a/lib/motor-controllers/talon-fx.ts
+++ b/lib/motor-controllers/talon-fx.ts
@@ -94,12 +94,14 @@ export const getMethods = () => ({
 
   getVelocityMethod: `return velocitySignal.getValueAsDouble() / gearRatio;`,
 
-  setPositionMethod: `double adjustedPosition = position * gearRatio;
+  setPositionMethod: `// Adjust for gear-ratio
+  double adjustedPosition = positionRotations * gearRatio;
 double ffVolts = feedforward.calculate(getVelocity(), acceleration);
 motor.setControl(positionRequest.withPosition(adjustedPosition).withFeedForward(ffVolts));`,
 
-  setVelocityMethod: `double adjustedVelocity = velocity * gearRatio;
-double ffVolts = feedforward.calculate(velocity, acceleration);
+  setVelocityMethod: `// Adjust for gear-ratio
+  double adjustedVelocity = velocityRotations * gearRatio;
+double ffVolts = feedforward.calculate(getVelocity(), acceleration);
 motor.setControl(velocityRequest.withVelocity(adjustedVelocity).withFeedForward(ffVolts));`,
 
   setVoltageMethod: `motor.setVoltage(voltage);`,

--- a/lib/motor-controllers/talon-fxs.ts
+++ b/lib/motor-controllers/talon-fxs.ts
@@ -2,7 +2,6 @@ export const getImports = () => `
 import com.ctre.phoenix6.hardware.TalonFXS;
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
-import com.ctre.phoenix6.controls.DutyCycleOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.signals.MotorArrangementValue;
@@ -19,7 +18,6 @@ import edu.wpi.first.units.measure.*;
 export const getDeclaration = () => `private final TalonFXS motor;
 private final PositionVoltage positionRequest;
 private final VelocityVoltage velocityRequest;
-private final DutyCycleOut dutyCycleRequest;
 private final StatusSignal<Angle> positionSignal;
 private final StatusSignal<AngularVelocity> velocitySignal;
 private final StatusSignal<Voltage> voltageSignal;
@@ -32,9 +30,8 @@ export const getInitialization = () => `motor = new TalonFXS(canID);
 // Create control requests
 positionRequest = new PositionVoltage(0).withSlot(0);
 velocityRequest = new VelocityVoltage(0).withSlot(0);
-dutyCycleRequest = new DutyCycleOut(0);
 
-// Track status signals
+// get status signals
 positionSignal = motor.getPosition();
 velocitySignal = motor.getVelocity();
 voltageSignal = motor.getMotorVoltage();
@@ -50,11 +47,12 @@ slot0.kP = kP;
 slot0.kI = kI;
 slot0.kD = kD;
 
-// Set ramp rates
 {{#if enableOpenLoopRamp}}
+// Set ramp rates
   OpenLoopRampsConfigs openLoopRamps = config.OpenLoopRamps;
   openLoopRamps.DutyCycleOpenLoopRampPeriod = openLoopRampRate;
 {{/if}}
+
 {{#if enableClosedLoopRamp}}
   ClosedLoopRampsConfigs closedLoopRamps = config.ClosedLoopRamps;
   closedLoopRamps.VoltageClosedLoopRampPeriod = closedLoopRampRate;
@@ -66,6 +64,7 @@ currentLimits.StatorCurrentLimit = statorCurrentLimit;
 currentLimits.StatorCurrentLimitEnable = enableStatorLimit;
 currentLimits.SupplyCurrentLimit = supplyCurrentLimit;
 currentLimits.SupplyCurrentLimitEnable = enableSupplyLimit;
+
 {{#if enableSoftLimits}}
 // Set soft limits
 SoftwareLimitSwitchConfigs softLimits = config.SoftwareLimitSwitch;
@@ -77,6 +76,9 @@ SoftwareLimitSwitchConfigs softLimits = config.SoftwareLimitSwitch;
 
 // Set brake mode
 config.MotorOutput.NeutralMode = brakeMode ? NeutralModeValue.Brake : NeutralModeValue.Coast;
+
+// Apply gear ratio
+config.Feedback.SensorToMechanismRatio = gearRatio;
 
 // Apply configuration
 motor.getConfigurator().apply(config);
@@ -92,19 +94,17 @@ export const getSimulationPeriodic = () => `
 `
 
 export const getMethods = () => ({
-  getPositionMethod: `return positionSignal.getValueAsDouble() / gearRatio;`,
+  getPositionMethod: `return positionSignal.getValueAsDouble();`,
 
-  getVelocityMethod: `return velocitySignal.getValueAsDouble() / gearRatio;`,
+  getVelocityMethod: `return velocitySignal.getValueAsDouble();`,
 
-  setPositionMethod: `// Adjust for gear-ratio
-  double adjustedPosition = positionRotations  * gearRatio;
+  setPositionMethod: `
 double ffVolts = feedforward.calculate(getVelocity(), acceleration);
-motor.setControl(positionRequest.withPosition(adjustedPosition).withFeedForward(ffVolts));`,
+motor.setControl(positionRequest.withPosition(positionRotations).withFeedForward(ffVolts));`,
 
-  setVelocityMethod: `// Adjust for gear-ratio
-  double adjustedVelocity = velocityRotations * gearRatio;
+  setVelocityMethod: `
 double ffVolts = feedforward.calculate(getVelocity(), acceleration);
-motor.setControl(velocityRequest.withVelocity(adjustedVelocity).withFeedForward(ffVolts));`,
+motor.setControl(velocityRequest.withVelocity(velocityRotations).withFeedForward(ffVolts));`,
 
   setVoltageMethod: `motor.setVoltage(voltage);`,
 

--- a/lib/motor-controllers/talon-fxs.ts
+++ b/lib/motor-controllers/talon-fxs.ts
@@ -96,12 +96,14 @@ export const getMethods = () => ({
 
   getVelocityMethod: `return velocitySignal.getValueAsDouble() / gearRatio;`,
 
-  setPositionMethod: `double adjustedPosition = position * gearRatio;
+  setPositionMethod: `// Adjust for gear-ratio
+  double adjustedPosition = positionRotations  * gearRatio;
 double ffVolts = feedforward.calculate(getVelocity(), acceleration);
 motor.setControl(positionRequest.withPosition(adjustedPosition).withFeedForward(ffVolts));`,
 
-  setVelocityMethod: `double adjustedVelocity = velocity * gearRatio;
-double ffVolts = feedforward.calculate(velocity, acceleration);
+  setVelocityMethod: `// Adjust for gear-ratio
+  double adjustedVelocity = velocityRotations * gearRatio;
+double ffVolts = feedforward.calculate(getVelocity(), acceleration);
 motor.setControl(velocityRequest.withVelocity(adjustedVelocity).withFeedForward(ffVolts));`,
 
   setVoltageMethod: `motor.setVoltage(voltage);`,


### PR DESCRIPTION
Before there was a loose implementation for getting the position, with no actual variable exisiting under "position". this applied to setVelocity as well.

This would be seen across all mechanism types, and TalonFX/FXS variants, 

```java

   * Set arm angle with acceleration.
   * @param angleDegrees The target angle in degrees
   * @param acceleration The acceleration in rad/s²
   */
  public void setAngle(double angleDegrees, double acceleration) {
    // Convert degrees to rotations
    double angleRadians = Units.degreesToRadians(angleDegrees);
    double positionRotations = angleRadians / (2.0 * Math.PI);

//here)
    double adjustedPosition = position * gearRatio;
    double ffVolts = feedforward.calculate(getVelocity(), acceleration);
    motor.setControl(
      positionRequest.withPosition(adjustedPosition).withFeedForward(ffVolts)
    );
  }

  /**
  
  ```
Now there is a comment explaining what the code does, and utilizing the "positionRotations"/"velocityRotations" to be used instead of the filler "position".



  
  