### PR TITLE
Fixed unit chosen not appearing in generated code

### DIFF
--- a/lib/code-generator.ts
+++ b/lib/code-generator.ts
@@ -44,6 +44,7 @@ async function processTemplate(templateName: string, data: FormValues): Promise<
   const templateData = {
     ...data,
     isSparkController: isRevController(data.motorControllerType),
+    Unit: data.telemetry.positionUnit,
     logPosition: data.telemetry.position,
     logVelocity: data.telemetry.velocity,
     logVoltage: data.telemetry.voltage,

--- a/public/templates/arm-subsystem.java.hbs
+++ b/public/templates/arm-subsystem.java.hbs
@@ -220,7 +220,7 @@ public class {{subsystemName}} extends SubsystemBase {
  private void updateTelemetry() {
    {{#if logPosition}}
    // Convert based on selected position unit
-   switch ("{{positionUnit}}") {
+   switch ("{{Unit}}") {
      case "Degrees":
        positionEntry.setDouble(Units.radiansToDegrees(getPositionRadians()));
        break;

--- a/public/templates/elevator-subsystem.java.hbs
+++ b/public/templates/elevator-subsystem.java.hbs
@@ -224,7 +224,7 @@ public class {{subsystemName}} extends SubsystemBase {
   private void updateTelemetry() {
     {{#if logPosition}}
     // Convert based on selected position unit
-    switch ("{{positionUnit}}") {
+    switch ("{{Unit}}") {
       case "Degrees":
         positionEntry.setDouble(Units.radiansToDegrees(getPositionRadians()));
         break;

--- a/public/templates/pivot-subsystem.java.hbs
+++ b/public/templates/pivot-subsystem.java.hbs
@@ -219,7 +219,7 @@ public void simulationPeriodic() {
 private void updateTelemetry() {
   {{#if logPosition}}
   // Convert based on selected position unit
-  switch ("{{positionUnit}}") {
+  switch ("{{Unit}}") {
     case "Degrees":
       positionEntry.setDouble(Units.radiansToDegrees(getPositionRadians()));
       break;


### PR DESCRIPTION
When generating code, the units for the PositionUnit type to be logged would not appear. With this commit, the chosen unit will be generated and displayed in the switch case. 